### PR TITLE
Slovakia VAT rate to 23%

### DIFF
--- a/pyvat/vat_rules.py
+++ b/pyvat/vat_rules.py
@@ -380,7 +380,7 @@ VAT_RULES = {
     'PT': PtVatRules(23),
     'RO': ConstantEuVatRateRules(19),
     'SE': SeVatRules(25),
-    'SK': ConstantEuVatRateRules(20),
+    'SK': ConstantEuVatRateRules(23),
     'SI': ConstantEuVatRateRules(22),
 }
 

--- a/tests/test_sale_vat_charge.py
+++ b/tests/test_sale_vat_charge.py
@@ -264,13 +264,13 @@ EXPECTED_VAT_RATES = {
         ItemType.enewspaper: Decimal(22),
     },
     'SK': {
-        ItemType.generic_physical_good: Decimal(20),
-        ItemType.generic_electronic_service: Decimal(20),
-        ItemType.generic_telecommunications_service: Decimal(20),
-        ItemType.generic_broadcasting_service: Decimal(20),
-        ItemType.prepaid_broadcasting_service: Decimal(20),
-        ItemType.ebook: Decimal(20),
-        ItemType.enewspaper: Decimal(20),
+        ItemType.generic_physical_good: Decimal(23),
+        ItemType.generic_electronic_service: Decimal(23),
+        ItemType.generic_telecommunications_service: Decimal(23),
+        ItemType.generic_broadcasting_service: Decimal(23),
+        ItemType.prepaid_broadcasting_service: Decimal(23),
+        ItemType.ebook: Decimal(23),
+        ItemType.enewspaper: Decimal(23),
     },
 }
 SUPPORTED_ITEM_TYPES = [


### PR DESCRIPTION
Sub-issue of https://github.com/wp-media/monies/issues/142

Slovakia `SK` VAT rate now is 23%