### PR TITLE
Added optional `postal_code` parameter to VAT rules calculation

### DIFF
--- a/pyvat/vat_rules.py
+++ b/pyvat/vat_rules.py
@@ -374,7 +374,8 @@ class EgVatRules():
                                        date,
                                        item_type,
                                        buyer,
-                                       seller):
+                                       seller,
+                                       postal_code=None):
         return VatCharge(VatChargeAction.charge,
                          buyer.country_code,
                          self.get_vat_rate(item_type))


### PR DESCRIPTION
Fix the bug to the egyptian rule being added and the postal code being added in parallel.

To fix the bug we added the postal code parameter to the egyptian rule.